### PR TITLE
fix: granularity of lint-stanged file types

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,0 +1,5 @@
+{
+    "*.(md|js|json)": "npm run format",
+    "*.sol": "npm run lint-sol -- --fix",
+    "*.ts":  "npm run lint-ts -- --fix"
+}

--- a/package.json
+++ b/package.json
@@ -54,13 +54,5 @@
   },
   "dependencies": {
     "bunyan": "^1.8.15"
-  },
-  "lint-staged": {
-    "*": [
-      "npm run format"
-    ],
-    "*.ts": [
-      "npm run lint-ts -- --fix"
-    ]
   }
 }


### PR DESCRIPTION
### Purpose for this PR
Prettier fails the husky task when it's given a file extension it cannot process. All of the config & ignore files cause problems, these are now not passed in by lint-staged.

Moved the config for lint-staged into it's own file, keeping consistent approach with all the other configs.