### PR TITLE
docs: conventional comments for development processes

### DIFF
--- a/docs/development_process.md
+++ b/docs/development_process.md
@@ -30,6 +30,12 @@ Messages for `git commit` and `git merge` operations comprise browsable log (`gi
 Consistency helps readers tremendously, please follow Conventional Commits
 https://www.conventionalcommits.org/en/v1.0.0/
 
+#### Pull Request review comments
+
+When Pull Requests (PRs) are used to merge code from a branch to `main`, they undergo review (seeking approval), where input from the reviewers will be received by the requester.
+
+To more effectively communicate their point, when raising a comment the reviewer structures their comment following [conventional commits](https://conventionalcomments.org/).
+
 ### TypeScript Style Guide
 
 Follow the Google TypeScript style guide, as they're sensible.

--- a/docs/development_process.md
+++ b/docs/development_process.md
@@ -32,7 +32,7 @@ https://www.conventionalcommits.org/en/v1.0.0/
 
 #### Pull Request review comments
 
-When Pull Requests (PRs) are used to merge code from a branch to `main`, they undergo review (seeking approval), where input from the reviewers will be received by the requester.
+When Pull Requests (PRs) are used to merge code from a branch, they undergo review (seeking approval), where input from the reviewers will be received by the requester.
 
 To more effectively communicate their point, when raising a comment the reviewer structures their comment following [conventional commits](https://conventionalcomments.org/).
 


### PR DESCRIPTION
### Purpose for this PR

<!-- Have you included adequate testing for this change? -->
I'm suggesting we adopt using the conventional commit format for our PR comments.

Reasoning: makes it easier to understand & prioritise comments.
