### PR TITLE
fix: absolute dependency to validate dependabot

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "solhint": "^3.3.6",
     "ts-node": "^10.2.1",
     "typechain": "^5.1.2",
-    "typescript": "^4.4.2"
+    "typescript": "4.4.2"
   },
   "dependencies": {
     "bunyan": "^1.8.15"


### PR DESCRIPTION
### Purpose for this PR

<!-- Have you included adequate testing for this change? -->
Not sure whether dependabot is actually checking the package dependencies, as it _may_ be working, but as the dependencies allow for minor version without needing a change, perhaps really nothing needs updated 🤔 

Changing TypeScript to an absolute, older version should trigger dependabot to raise a PR.